### PR TITLE
Exclude built in container types from inheritance

### DIFF
--- a/lib/src/main/resources/handlebars/springcodegen/pojo.mustache
+++ b/lib/src/main/resources/handlebars/springcodegen/pojo.mustache
@@ -1,7 +1,7 @@
 {{#discriminator}}{{>typeInfoAnnotation}}{{/discriminator}}
 
 @Data
-{{#vendorExtensions.x-inheritance}}@SuperBuilder{{/vendorExtensions.x-inheritance}}
+{{#vendorExtensions.x-inheritance}}{{^isContainer}}@SuperBuilder{{/isContainer}}{{/vendorExtensions.x-inheritance}}
 {{^vendorExtensions.x-inheritance}}@Builder{{/vendorExtensions.x-inheritance}}
 {{#parent}}@EqualsAndHashCode(callSuper=true){{/parent}}
 @AllArgsConstructor


### PR DESCRIPTION
Motivation.
When you have something like:
```
  InheritedObject:
    type: object
    additionalProperties:
      type: object
```
you get java code similar to this:
```
...
@SuperBuilder
...
public class EventDetails extends HashMap<String, Object> implements Serializable {}
```

However lombok does not like super builder on top of HashMap.